### PR TITLE
4 add logic for json path

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^vitorcid\.Rproj$
 ^\.Rproj\.user$
 ^\.httr-oauth$
+^vignette/.httr-oauth$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Imports:
    jsonlite,
    magick,
    pkgsearch,
-   rcrossref,
    RCurl,
    rmarkdown,
    rorcid,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vitorcid
 Title: A wrapper of vitae create a CV with the data fetched from ORCID database
-Version: 0.0.0.9000
+Version: 0.0.1
 Authors@R: 
     person("Arkadiusz", "Gladki", , "arek@gladki.pl", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))
@@ -15,6 +15,7 @@ Imports:
    jsonlite,
    magick,
    pkgsearch,
+   rcrossref,
    RCurl,
    rmarkdown,
    rorcid,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,6 @@
+## gDRstyle 0.0.1 - 2024-03-24
+* add support for CV customization via JSON file
+* fix bug (invalid `why` column in vitae entry)
+
+## gDRutils 0.0.0.9000 - 2024-03-12
+* initial commit

--- a/R/json.R
+++ b/R/json.R
@@ -50,8 +50,8 @@ get_supported_entries <-
 
 #' @keywords .internal
 get_json_names <-
-  function(json_path) {
+  function(json_path = system.file(package = "vitorcid", "config.json")) {
     checkmate::assert_file_exists(json_path)
     gjd(names_only = TRUE,
-        json_path = system.file(package = "vitorcid", "config.json"))
+        json_path = json_path)
   }

--- a/R/package.R
+++ b/R/package.R
@@ -1,0 +1,13 @@
+#' @import gDRcomponents
+#' @import gDRutils
+#' @import shiny
+#' @import shinydashboard
+#' @import magrittr
+#' @importFrom data.table as.data.table data.table :=
+#' @importFrom lobstr obj_size
+NULL
+
+# Prevent R CMD check from complaining about some vars
+# a) standard data.table variables
+utils::globalVariables(c("why"),
+                       utils::packageName())

--- a/R/rorcid.R
+++ b/R/rorcid.R
@@ -14,25 +14,27 @@
 #' @keywords vitae
 #'
 get_cv <-
-  function(out_file = "CV",
+  function(out_file = file.path(getwd(), "CV"),
            orcid = Sys.getenv("ORCID_ID"),
            output_type = c("Rmd", "pdf"),
            json_path = NULL,
            entries = c("education", "employment", "r_package", "citation")) {
-    cvl <- get_cv_data(orcid = orcid)
-    header_yaml <- get_cv_header(orcid = orcid, output_type = "yaml")
+    cvl <- get_cv_data(orcid = orcid, json_path = json_path)
+    header_yaml <-
+      get_cv_header(orcid = orcid,
+                    output_type = "yaml",
+                    json_path = json_path)
     rmd_tmpfile <- tempfile(fileext = ".Rmd")
     write("---", rmd_tmpfile)
     write(header_yaml, rmd_tmpfile, append = TRUE)
     write("---", rmd_tmpfile, append = TRUE)
 
     rmd_str <-
-      "```{r setup, include=FALSE}
+      sprintf("```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
 library(vitorcid)
-cvl <- get_cv_data()
-
-```"
+cvl <- get_cv_data(orcid = \"%s\", json_path = \"%s\")
+```", orcid, json_path)
 
     if (!is.null(cvl$pd$summary)) {
       rmd_str <- c(
@@ -86,17 +88,43 @@ cvl[[\"%s\"]]
 #' @keywords vitae
 #'
 get_cv_header <- function(orcid = Sys.getenv("ORCID_ID"),
+                          json_path = NULL,
                           output_type = c("list", "yaml")) {
+  
   output_type <- match.arg(output_type)
-
-  pd <- get_personal_data(orcid)
-  links_l <-
-    as.list(structure(pd$links$url.value, names = pd$links$`url-name`))
   shf <- gjd("supported_header_fields",
              json_path = system.file(package = "vitorcid", "config.json"))
 
   huv <- gjd("header_urls_to_validate",
              json_path = system.file(package = "vitorcid", "config.json"))
+
+  pd <- get_personal_data(orcid)
+  links_l <-
+    as.list(structure(pd$links$url.value, names = pd$links$`url-name`))
+ 
+  # get header data from JSON file (if present) 
+  hd_l <-
+    if (!is.null(json_path) &&
+        "header_data" %in% get_json_names(json_path)) {
+      out_l <- gjd("header_data", json_path = json_path)
+      if (!all(names(out_l) %in% shf)) {
+        stop(
+          sprintf(
+            "Some entries in 'header_data' (from JSON file) are not supported: '%s'. Select on from: '%s'",
+            toString(setdiff(names(out_l), shf)),
+            toString(shf)
+          )
+        )
+      }
+      out_l
+    } else {
+      list()
+    }
+  
+  # mergee header data from JSON file with data from ORCID 
+  # (with higher priority given to values from JSON file)
+  links_l <- utils::modifyList(links_l, hd_l)
+  
   for (entry in huv) {
     if (entry %in% names(links_l)) {
       if (!validate_url(links_l[[entry]])) {
@@ -156,7 +184,7 @@ get_cv_data <-
            json_path = NULL,
            entries = c("education", "employment", "r_package", "citation")) {
     ml <- lapply(entries, function(entry) {
-      get_vitae_entry(entry, orcid)
+      get_vitae_entry(entry, orcid,json_path = json_path)
     })
     names(ml) <- entries
     ml$pd <- get_personal_data(orcid)

--- a/R/rorcid.R
+++ b/R/rorcid.R
@@ -29,12 +29,17 @@ get_cv <-
     write(header_yaml, rmd_tmpfile, append = TRUE)
     write("---", rmd_tmpfile, append = TRUE)
 
+    json_path_str <- if (is.null(json_path)) {
+      "NULL"
+    } else {
+      sprintf("'%s'", json_path)
+    }
     rmd_str <-
       sprintf("```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
 library(vitorcid)
-cvl <- get_cv_data(orcid = \"%s\", json_path = \"%s\")
-```", orcid, json_path)
+cvl <- get_cv_data(orcid = '%s', json_path = %s)
+```", orcid, json_path_str)
 
     if (!is.null(cvl$pd$summary)) {
       rmd_str <- c(
@@ -81,6 +86,7 @@ cvl[[\"%s\"]]
 #'
 #' @param orcid string with the ORCID ID
 #'  by default fetched fomr "ORCID_ID" system variable
+#' @param json_path string to JSON file with additional/custom data
 #' @param output_type string with output format ('list' or 'yaml'
 #'
 #' return list or YAML with header data
@@ -184,7 +190,7 @@ get_cv_data <-
            json_path = NULL,
            entries = c("education", "employment", "r_package", "citation")) {
     ml <- lapply(entries, function(entry) {
-      get_vitae_entry(entry, orcid,json_path = json_path)
+      get_vitae_entry(entry, orcid, json_path = json_path)
     })
     names(ml) <- entries
     ml$pd <- get_personal_data(orcid)

--- a/R/vitae.R
+++ b/R/vitae.R
@@ -78,7 +78,7 @@ get_vitae_detailed_entry <- function(entry_type,
     with = e_dt$with,
     where = e_dt$where,
     when = e_dt$when,
-    why = e_dt$why
+    why = why
   )
 }
 
@@ -172,7 +172,7 @@ get_vitae_r_package_entry <-
       with = pp$with,
       where = pp$where,
       when = pp$when,
-      why = pp$why
+      why = why
     )
   }
 
@@ -182,7 +182,7 @@ add_why <- function(e_dt, entry_type, why, json_path = NULL) {
   if (is.null(why) &&
       !(is.null(json_path)) &&
       entry_type %in% get_json_names(json_path = json_path)) {
-    e_why <- gjd(entry_type)
+    e_why <- gjd(entry_type, json_path = json_path)
     checkmate::assert_data_table(e_why)
     checkmate::assert_true("why" %in% names(e_why))
     checkmate::assert_true(any(c("put-code", "idx") %in% names(e_why)))

--- a/inst/json_examples/orcid_0000-0002-7059-6378_email.json
+++ b/inst/json_examples/orcid_0000-0002-7059-6378_email.json
@@ -1,0 +1,5 @@
+{
+  "header_data": {
+    "email": "new_email@email.com"
+  }
+} 

--- a/inst/json_examples/orcid_0000-0002-7059-6378_header_data.json
+++ b/inst/json_examples/orcid_0000-0002-7059-6378_header_data.json
@@ -1,0 +1,6 @@
+{
+  "header_data": {
+    "position": "Bioinformatician and R programmer",
+    "address": "Skierniewice, Poland"
+  }
+} 

--- a/inst/json_examples/orcid_0000-0002-7059-6378_profilepic.json
+++ b/inst/json_examples/orcid_0000-0002-7059-6378_profilepic.json
@@ -1,0 +1,5 @@
+{
+  "header_data": {
+    "profilepic": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Curriculum-vitae-warning-icon.svg/240px-Curriculum-vitae-warning-icon.svg.png"
+  }
+} 

--- a/inst/json_examples/orcid_0000-0002-7059-6378_why_idx.json
+++ b/inst/json_examples/orcid_0000-0002-7059-6378_why_idx.json
@@ -1,0 +1,30 @@
+{
+  "employment": [
+    {
+      "idx": 1,
+      "why": "developing biomedical R packages, especially those related to Next-Generation Sequencing data__developing R/Shiny application for visualization of NGS data__developing R/Shiny application for visualization of dose-response data (technical leader)"
+    },
+    {
+      "idx": 2,
+      "why": "conducting classes (bioinformatics basics) for Biotechnology students (Faculty of Chemistry)"
+    },
+    {
+      "idx": 3,
+      "why": "conducting in silico research__presenting the findings during conferences__developing bioinformatics pipelines__conducting classes (bioinformatics basics)__mentoring undergraduate students"
+    },
+    {
+      "idx": 4,
+      "why": "manual testing of webservices"
+    }
+  ],
+  "education": [
+    {
+      "idx": 1,
+      "why": "PhD thesis title: Evolution of dominance and antibacterial drug targets"
+    },
+    {
+      "idx": 2,
+      "why": "Master thesis title: Inferring potential bubonic plague drug targets from the analysis of predicted protein interactions network of Yersinia pestis KIM"
+    }
+  ]
+} 

--- a/inst/json_examples/orcid_0000-0002-7059-6378_why_put-code.json
+++ b/inst/json_examples/orcid_0000-0002-7059-6378_why_put-code.json
@@ -1,0 +1,30 @@
+{
+  "employment": [
+    {
+      "put-code": 21893486,
+      "why": "developing biomedical R packages, especially those related to Next-Generation Sequencing data__developing R/Shiny application for visualization of NGS data__developing R/Shiny application for visualization of dose-response data (technical leader)"
+    },
+    {
+      "put-code": 21893493,
+      "why": "conducting classes (bioinformatics basics) for Biotechnology students (Faculty of Chemistry)"
+    },
+    {
+      "put-code": 21893501,
+      "why": "conducting in silico research__presenting the findings during conferences__developing bioinformatics pipelines__conducting classes (bioinformatics basics)__mentoring undergraduate students"
+    },
+    {
+      "put-code": 21893522,
+      "why": "manual testing of webservices"
+    }
+  ],
+  "education": [
+    {
+      "put-code": 21893544,
+      "why": "PhD thesis title: Evolution of dominance and antibacterial drug targets"
+    },
+    {
+      "put-code": 21893532,
+      "why": "Master thesis title: Inferring potential bubonic plague drug targets from the analysis of predicted protein interactions network of Yersinia pestis KIM"
+    }
+  ]
+} 

--- a/man/get_cv.Rd
+++ b/man/get_cv.Rd
@@ -5,7 +5,7 @@
 \title{get CV}
 \usage{
 get_cv(
-  out_file = "CV",
+  out_file = file.path(getwd(), "CV"),
   orcid = Sys.getenv("ORCID_ID"),
   output_type = c("Rmd", "pdf"),
   json_path = NULL,

--- a/man/get_cv_header.Rd
+++ b/man/get_cv_header.Rd
@@ -4,11 +4,17 @@
 \alias{get_cv_header}
 \title{get CV header}
 \usage{
-get_cv_header(orcid = Sys.getenv("ORCID_ID"), output_type = c("list", "yaml"))
+get_cv_header(
+  orcid = Sys.getenv("ORCID_ID"),
+  json_path = NULL,
+  output_type = c("list", "yaml")
+)
 }
 \arguments{
 \item{orcid}{string with the ORCID ID
 by default fetched fomr "ORCID_ID" system variable}
+
+\item{json_path}{string to JSON file with additional/custom data}
 
 \item{output_type}{string with output format ('list' or 'yaml'
 

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -1,0 +1,4 @@
+library(testthat)
+
+testthat::expect_true(TRUE)
+

--- a/vignette/vitorcid.Rmd
+++ b/vignette/vitorcid.Rmd
@@ -1,0 +1,80 @@
+---
+title: "Introduction to vitorcid"
+description: >
+  Learn how to get started with the basics of vitorcid.
+author: "vitorcid team"
+vignette: >
+  %\VignetteIndexEntry{vitorcid}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(vitorcid)
+```
+
+# Overview
+To be added soon.
+
+# Use cases
+
+## Customizing CV data with JSON file
+
+Sometimes one might want to customize the CV data. There are three general cases:
+* adding the data unavailable from orcid.org
+* overwriting the data fetched from orcid.org 
+* adding the data not provided at orcid.org
+
+####  Header data
+Currently, there are two header entries that can be provided only via JSON file: 'position' and 'address'. Here is the example JSON file with both entries defined: 
+```{r}
+j_path <- system.file(package = "vitorcid", "json_examples/orcid_0000-0002-7059-6378_header_data.json")
+jsonlite::toJSON(jsonlite::fromJSON(j_path), pretty = TRUE)
+```
+
+Sometimes, user might want to update the email or profile picture:
+```{r}
+j_path <- system.file(package = "vitorcid", "json_examples/orcid_0000-0002-7059-6378_email.json")
+jsonlite::toJSON(jsonlite::fromJSON(j_path), pretty = TRUE)
+
+j_path <- system.file(package = "vitorcid", "json_examples/orcid_0000-0002-7059-6378_profilepic.json")
+jsonlite::toJSON(jsonlite::fromJSON(j_path), pretty = TRUE)
+```
+
+One can use the JSON data while getting the latest CV in the following way:
+```{r, eval = FALSE}
+vitorcid::get_cv(json_path = j_path)
+```
+
+
+### Non-header data
+One is not able to provide details about specific employment or education entries at the orcid.org. Here is the example of defining such details for the user with ORCID ID: "0000-0002-7059-6378". In his case there are four employment and two education entries (see details [here]( https://orcid.org/0000-0002-7059-6378/print).
+
+```{r}
+# defining details with idx (counting from the top to the bottom)
+j_path <- system.file(package = "vitorcid", "json_examples/orcid_0000-0002-7059-6378_why_idx.json")
+jsonlite::toJSON(jsonlite::fromJSON(j_path), pretty = TRUE)
+
+# defining details with put-code(s) from orcid.org
+# each put-code refers to the given record from education/employment
+j_path <- system.file(package = "vitorcid", "json_examples/orcid_0000-0002-7059-6378_why_put-code.json")
+jsonlite::toJSON(jsonlite::fromJSON(j_path), pretty = TRUE)
+```
+
+One can use the JSON data while getting the latest CV in the following way:
+```{r, eval = FALSE}
+vitorcid::get_cv(json_path = j_path)
+```
+
+# SessionInfo {-}
+
+```{r sessionInfo}
+sessionInfo()
+```


### PR DESCRIPTION
# Summary
 - add logic for handling custom data from JSON file
 - doc: add vignette with info on how to customize CV via JSON file
 - bugfix: why data in vitae entry
 - fix R CMD CHECK notes
 - init `testthat` infrastructure